### PR TITLE
Changed to sort in C-locale in createOrderKey() using the stringi-pac…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxData
-Version: 1.1.7
-Date: 2021-05-06
+Version: 1.1.8
+Date: 2021-05-10
 Title: Tools to Read and Manipulate Fisheries Data
 Authors@R: c(
   person(given = "Ibrahim", 
@@ -38,7 +38,8 @@ Imports:
     Rcpp (>= 1.0.0),
     xml2 (>= 1.2.2),
     xslt (>= 1.4),
-    units (>= 0.7)
+    units (>= 0.7),
+    stringi (>= 1.4.3)
 Suggests: 
     testthat
 LinkingTo: 

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -664,7 +664,10 @@ createOrderKey <- function(x, split = "/") {
 	}
 	
 	# Convert to integer ranks:
-	splittedDT[, names(splittedDT) := lapply(.SD, function(y) match(y, sort(unique(y))))]
+	#splittedDT[, names(splittedDT) := lapply(.SD, function(y) match(y, sort(unique(y))))]
+	# Replicate data.table's soring which happend in C-locale (see ?data.table::setorderv):
+	splittedDT[, names(splittedDT) := lapply(.SD, function(y) match(y, stringi::stri_sort(unique(y), locale = "C")))]
+	
 
 	# Count the maximum number of digits for each column, and multiply by the cummulative number of digits:
 	numberOfDigits <- splittedDT[, lapply(.SD, max)]


### PR DESCRIPTION
…kage, to comply with data.table's philosophy of platform independence.