### PR TITLE
Fixed bug in the JSON schema of the Translation process data, where n…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxData
-Version: 1.6.5
-Date: 2022-06-18
+Version: 1.6.6
+Date: 2022-06-19
 Title: Tools to Read and Manipulate Fisheries Data
 Authors@R: c(
   person(given = "Edvin", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# RstoxData v1.6.6  (2022-06-19)
+* Fixed bug in the JSON schema of the Translation process data, where number, string and boolean were allowed for the NewValue field, in that order, whereas string and null is correct.
+* Fixed bug in as.POSIXct_ICESAcoustic() where the minute resoslution was tested first, causing loss of available seconds.
+
 # RstoxData v1.6.5  (2022-06-17)
 * Fixed bug in StoxAcoustic() where LogKey in ICESAcoustic data was misspecified when using time format "YYYY-MM-DDThh:mm" or "YYYY-MM-DD hh:mm" (without seconds). The seconds (00) are now included.
 * Fixed bug in StoxBiotic() where the time format "YYYY-MM-DDThh:mm" in an ICESBiotic xml files was truncated to only the date.

--- a/R/StoxAcoustic.R
+++ b/R/StoxAcoustic.R
@@ -361,6 +361,7 @@ StoxAcousticOne <- function(data_list) {
 		#         Fiks to correct time format, and add to key           #
 		#################################################################
 		#data_list$Log[, LogKey:= paste0(gsub(' ','T',Time),'.000Z')]
+		browser()
 		data_list$Log[, LogKey := formatLogKey(as.POSIXct_ICESAcoustic(Time))]
 		
 		data_list$Log[, EDSU:= paste(LocalID,LogKey,sep='/')]
@@ -522,6 +523,7 @@ StoxAcousticOne <- function(data_list) {
 		### data_list$Log$Latitude2 <- NA_real_
 		
 		# Convert to POSIX.ct:
+		browser()
 		data_list$Log[, DateTime := as.POSIXct_ICESAcoustic(DateTime)]
 		
 		
@@ -627,8 +629,8 @@ as.POSIXct_ICESAcoustic <- function(x) {
 		"%Y-%m-%d %H:%M"
 	)
 	allowedTimeFormatsICESAcoustic <- c(
-		allowedTimeFormatsICESAcousticSansSeconds, 
-		paste0(allowedTimeFormatsICESAcousticSansSeconds, ":%OS")
+		paste0(allowedTimeFormatsICESAcousticSansSeconds, ":%OS"), 
+		allowedTimeFormatsICESAcousticSansSeconds
 	)
 	
 	areNotNAs <- !is.na(x)

--- a/inst/formats/processDataSchema.json
+++ b/inst/formats/processDataSchema.json
@@ -6,7 +6,7 @@
 			{
 				"type": "object",
 				"properties": {
-					"NewValue": { "type": ["number","string","boolean"] }
+					"NewValue": { "type": ["string", "null"] }
 				},
 				"required": [
 					"NewValue"


### PR DESCRIPTION
…umber, string and boolean were allowed for the NewValue field, in that order, whereas string and null is correct. Fixed bug in as.POSIXct_ICESAcoustic() where the minute resoslution was tested first, causing loss of available seconds.