### PR TITLE
Start of using semantic versioning (https://semver.org/). Before this…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxData
-Version: 1.6.8
-Date: 2022-08-06
+Version: 1.7.0
+Date: 2022-08-11
 Title: Tools to Read and Manipulate Fisheries Data
 Authors@R: c(
   person(given = "Edvin", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# RstoxData v1.7.0  (2022-08-11)
+* Start of using semantic versioning (https://semver.org/). Before this release the two first version numbers represented the major and minor release number, in accordance with semantic versioning, whereas the third version number identified test versions. The major and minor releases (versions ending with 0.0 or 0) were considered as official versions. From this release and onwards, the third version number will represent patches (bug fixes), and are to be considered equally official as the major and minor releases. In fact, as patches are restricted to fixing bugs and not adding new functionality, the latest patch will be the recommended version.
+
 # RstoxData v1.6.8  (2022-08-07)
 * Fixed bug in getLogKey_ICESAcoustic().
 * Disabled warning in Translate-functions when a table contained some but not all of the variables of the Translation. 

--- a/R/StoxAcoustic.R
+++ b/R/StoxAcoustic.R
@@ -504,7 +504,7 @@ hasMinuteResoslution_ICESAcoustic <- function(Time) {
 getLogKey_ICESAcoustic <- function(Time) {
 	# Use the old form "2021-06-30T03:11.000Z", which was an error, but add a warning stating that the LogKey and DateTime will not correspond, and that we recommend using seconds resoslution:
 	if(hasMinuteResoslution_ICESAcoustic(Time)) {
-		warning("StoX: The AcousticData contains data read from ICESAcoustic files with minute resolution (seconds not given) in the Time field of the Log table. This is accepted when creating the DateTime field in the StoxAcousticData, but will for backwards compatibility to RstoxData 1.6.0 and older result in the time part of the LogKey and EDSU in the form YYYY-MM-DDThh:mm.000Z instead of the more reasonable YYYY-MM-DDThh:mm:ss.000Z. It is generally recommended to use ICESAcoustic data with secondss resolution.")
+		warning("StoX: The AcousticData contains data read from ICESAcoustic files with minute resolution (seconds not given) in the Time field of the Log table. This is accepted when creating the DateTime field in the StoxAcousticData, but will for backwards compatibility to RstoxData 1.6.0 and older result in the time part of the LogKey and EDSU in the form YYYY-MM-DDThh:mm.000Z instead of the more reasonable YYYY-MM-DDThh:mm:ss.000Z. It is generally recommended to use ICESAcoustic data with seconds resolution.")
 		# Use the code from RstoxData 1.6.0, file StoxAcoustic.R, line 354 (https://github.com/StoXProject/RstoxData/blob/RstoxData-v1.6.0/R/StoxAcoustic.R#L354):
 		paste0(gsub(' ', 'T', Time),'.000Z')
 	}


### PR DESCRIPTION
… release the two first version numbers represented the major and minor release number, in accordance with semantic versioning, whereas the third version number identified test versions. The major and minor releases (versions ending with 0.0 or 0) were considered as official versions. From this release and onwards, the third version number will represent patches (bug fixes), and are to be considered equally official as the major and minor releases. In fact, as patches are restricted to fixing bugs and not adding new functionality, the latest patch will be the recommended version.